### PR TITLE
Add qunit-plugin keyword to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "keywords": [
     "qunit",
+    "qunit-plugin",
     "test",
     "testing",
     "retry"


### PR DESCRIPTION
We've redesigned the site recently and the [plugin directory](https://qunitjs.com/plugins/) is now managed through npm keyword.

Give me a ping after the next release (e.g. a simple patch release) so I can kick off a re-build for you!

Ref https://github.com/qunitjs/qunitjs.com/pull/147.
