### PR TITLE
Clarify the using maxRuns [Issue 8]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.env
+node_modules

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ Use very sparingly, for a suite of 2024 tests, using this for a single acceptanc
 
 Blog post about `qunit-retry` available [here](https://blog.mrloop.com/javascript/2019/02/26/qunit-retry.html).
 
+### Set Max Runs
+
+To change the number of retries, set a value in the third parameter (`maxRuns`). The default value for `maxRuns` is `2` (one attempt and one retry):
+
+```js
+// retry this test **two times** (in addition to one initial attempt)
+// on failure as third party service occasionally fails
+// we need to test against third party service
+// we can live with occasional third party service failure
+retry("a test relying on 3rd party service that occasionally fails", async function(assert) {
+  var result = await occasionallyFailingServiceTestResult();
+  assert.equal(result, 42);
+}, 3);
+```
+
+**Note:** It is generally advised to use the retry sparingly and this advice extends to setting a large number of retries.
 
 Install
 ------------------------------------------------------------------------------

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,7 +1,7 @@
 import AssertResultHandler from './assert-result-handler.js'
 
 export default class Retry {
-  constructor (name, callback, maxRuns, testFn) {
+  constructor (name, callback, maxRuns = 2, testFn) {
     this.name = name
     this.callback = callback
     this.maxRuns = maxRuns

--- a/test/retry.js
+++ b/test/retry.js
@@ -26,7 +26,7 @@ QUnit.module('test retries, should stop at 3 retries', hooks => {
   }, 5)
 })
 
-retry('test default retry twice', function (assert, currentRun) {
+retry('test default: retry runs twice - initial attempt plus one retry', function (assert, currentRun) {
   assert.expect(1)
   assert.equal(currentRun, 2)
 })


### PR DESCRIPTION
Closes #8 

Inspecting the tests, it seems that this was already demonstrated, however, I still think there's value in clarifying the defaults and covering it in the README.

- Made the default value of 1 explicit
- Clarified test case covering default
- Added context to README
