### PR TITLE
chore(deps): update qunit to 2.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.3.1",
-        "qunit": "^2.14.1",
+        "qunit": "^2.22.0",
         "release-it": "^17.10.0",
         "testem": "^3.4.0"
       }
@@ -1896,9 +1896,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-      "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -4874,12 +4874,6 @@
         "node": "^18.17 || >=20.6.1"
       }
     },
-    "node_modules/js-reporters": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.3.tgz",
-      "integrity": "sha512-2YzWkHbbRu6LueEs5ZP3P1LqbECvAeUJYrjw3H4y1ofW06hqCS0AbzBtLwbr+Hke51bt9CUepJ/Fj1hlCRIF6A==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5946,9 +5940,9 @@
       }
     },
     "node_modules/node-watch": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
-      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -6858,15 +6852,14 @@
       ]
     },
     "node_modules/qunit": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.14.1.tgz",
-      "integrity": "sha512-jtFw8bf8+GjzY8UpnwbjqTOdK/rvrjcafUFTNpRc6/9N4q5dBwcwSMlcC76kAn5BRiSFj5Ssn2dfHtEYvtsXSw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.22.0.tgz",
+      "integrity": "sha512-wPYvAvpjTL3zlUeyCX75T8gfZfdVXZa8y1EVkGe/XZNORIsCH/WI2X8R2KlemT921X9EKSZUL6CLGSPC7Ks08g==",
       "dev": true,
       "dependencies": {
-        "commander": "7.1.0",
-        "js-reporters": "1.2.3",
-        "node-watch": "0.7.1",
-        "tiny-glob": "0.2.8"
+        "commander": "7.2.0",
+        "node-watch": "0.7.3",
+        "tiny-glob": "0.2.9"
       },
       "bin": {
         "qunit": "bin/qunit.js"
@@ -8171,9 +8164,9 @@
       }
     },
     "node_modules/tiny-glob": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
-      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "dev": true,
       "dependencies": {
         "globalyzer": "0.1.0",
@@ -10251,9 +10244,9 @@
       "dev": true
     },
     "commander": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
-      "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
     },
     "compressible": {
@@ -12436,12 +12429,6 @@
         "lodash.uniqby": "^4.7.0"
       }
     },
-    "js-reporters": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.3.tgz",
-      "integrity": "sha512-2YzWkHbbRu6LueEs5ZP3P1LqbECvAeUJYrjw3H4y1ofW06hqCS0AbzBtLwbr+Hke51bt9CUepJ/Fj1hlCRIF6A==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13162,9 +13149,9 @@
       }
     },
     "node-watch": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
-      "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -13835,15 +13822,14 @@
       "dev": true
     },
     "qunit": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.14.1.tgz",
-      "integrity": "sha512-jtFw8bf8+GjzY8UpnwbjqTOdK/rvrjcafUFTNpRc6/9N4q5dBwcwSMlcC76kAn5BRiSFj5Ssn2dfHtEYvtsXSw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.22.0.tgz",
+      "integrity": "sha512-wPYvAvpjTL3zlUeyCX75T8gfZfdVXZa8y1EVkGe/XZNORIsCH/WI2X8R2KlemT921X9EKSZUL6CLGSPC7Ks08g==",
       "dev": true,
       "requires": {
-        "commander": "7.1.0",
-        "js-reporters": "1.2.3",
-        "node-watch": "0.7.1",
-        "tiny-glob": "0.2.8"
+        "commander": "7.2.0",
+        "node-watch": "0.7.3",
+        "tiny-glob": "0.2.9"
       }
     },
     "range-parser": {
@@ -14815,9 +14801,9 @@
       }
     },
     "tiny-glob": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
-      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "dev": true,
       "requires": {
         "globalyzer": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
-    "qunit": "^2.14.1",
+    "qunit": "^2.22.0",
     "release-it": "^17.10.0",
     "testem": "^3.4.0"
   },


### PR DESCRIPTION
It upgrades Qunit to 2.22.0 which should allow us to use `this.test.hooks('beforeEach')` directly