### PR TITLE
feat: reset test environment on each retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.env
 node_modules
+.vscode

--- a/src/extend.js
+++ b/src/extend.js
@@ -1,0 +1,13 @@
+export default function extend (a, b, undefOnly, allProperties) {
+  for (const prop in b) {
+    if (Object.hasOwn.call(b, prop) || allProperties) {
+      if (b[prop] === undefined) {
+        delete a[prop]
+      } else if (!(undefOnly && typeof a[prop] !== 'undefined')) {
+        a[prop] = b[prop]
+      }
+    }
+  }
+
+  return a
+}

--- a/src/retry.js
+++ b/src/retry.js
@@ -1,4 +1,5 @@
 import AssertResultHandler from './assert-result-handler.js'
+import extend from './extend.js'
 
 export default class Retry {
   constructor (name, callback, maxRuns = 2, testFn) {
@@ -58,6 +59,7 @@ export default class Retry {
 
   async runTest () {
     if (this.notFirstRun) {
+      this.test.testEnvironment = extend({}, this.test.module.testEnvironment, false, true)
       await this.runHooks(this.beforeEachHooks)
     }
     await this.tryTest()

--- a/test/retry.js
+++ b/test/retry.js
@@ -62,6 +62,12 @@ QUnit.module('hook context', function (hooks) {
     assert.equal(this.sharedValue, 'myContext')
     assert.equal(currentRun, 2)
   })
+
+  retry('environment it reset on each retry', function (assert, currentRun) {
+    assert.equal(this.localValue, undefined)
+    this.localValue = 'local'
+    assert.equal(currentRun, 2)
+  })
 })
 
 QUnit.module('currentRun count', function () {


### PR DESCRIPTION
This MR introduces environment reset on each retry.

Previously, some variables leaked between reruns. To prevent that, we replicate [the same extend behavior that is included in qunit](https://github.com/qunitjs/qunit/blob/bf42d2b7738d7be9ee638fd41359eff6f1ca12c1/src/core/test.js#L489).