### PR TITLE
testem todo reporting issues example

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -13,15 +13,23 @@
 
       const retry = setup(QUnit.test)
 
-      QUnit.module('test retries and result message', hooks => {
-        hooks.after(assert => {
-          assert.equal(QUnit.config.current.assertions[0].message, '(Retried 6 times)', 'message shows retries')
-        })
+      // QUnit.module('test retries and result message', hooks => {
+      //   hooks.after(assert => {
+      //     assert.equal(QUnit.config.current.assertions[0].message, '(Retried 6 times)', 'message shows retries')
+      //   })
 
-        retry('test default retry six times', function (assert, currentRun) {
-          assert.equal(currentRun, 6)
-        }, 6)
-      })
+      //   retry('test default retry six times', function (assert, currentRun) {
+      //     assert.equal(currentRun, 6)
+      //   }, 6)
+      // })
+
+      QUnit.todo('it should pass when an assertion fails', function (assert) {
+        assert.equal(1, 2)
+      });
+
+      QUnit.todo('it should fail when an assertion passes', function (assert) {
+        assert.equal(1, 1)
+      });
     </script>
     <link rel="stylesheet" href="./qunit-retry/node_modules/qunit/qunit/qunit.css">
   </head>

--- a/test/retry.js
+++ b/test/retry.js
@@ -1,120 +1,128 @@
-const setup = require('../index.js')
+// const setup = require('../index.js')
 const QUnit = require('qunit')
-const timeout = function (ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
+// const timeout = function (ms) {
+//   return new Promise(resolve => setTimeout(resolve, ms))
+// }
 
-const retry = setup(QUnit.test)
+// const retry = setup(QUnit.test)
 
-QUnit.module('test retries and result message', hooks => {
-  hooks.after(assert => {
-    assert.equal(QUnit.config.current.assertions[0].message, '(Retried 5 times)', 'message shows retries')
-  })
-
-  retry('test retry five times', function (assert, currentRun) {
-    assert.equal(currentRun, 5)
-  }, 5)
+QUnit.todo('it should pass when an assertion fails', function (assert) {
+  assert.equal(1, 2)
 })
 
-QUnit.module('test retries, should stop at 3 retries', hooks => {
-  hooks.after(assert => {
-    assert.equal(QUnit.config.current.assertions[0].message, '(Retried 3 times)', 'message shows retries')
-  })
-
-  retry('test retry five times', function (assert, currentRun) {
-    assert.equal(currentRun, 3)
-  }, 5)
+QUnit.todo('it should fail when an assertion passes', function (assert) {
+  assert.equal(1, 1)
 })
 
-retry('test default: retry runs twice - initial attempt plus one retry', function (assert, currentRun) {
-  assert.expect(1)
-  assert.equal(currentRun, 2)
-})
+// QUnit.module('test retries and result message', hooks => {
+//   hooks.after(assert => {
+//     assert.equal(QUnit.config.current.assertions[0].message, '(Retried 5 times)', 'message shows retries')
+//   })
 
-retry('test retry five times', function (assert, currentRun) {
-  assert.expect(1)
-  assert.equal(currentRun, 5)
-}, 5)
+//   retry('test retry five times', function (assert, currentRun) {
+//     assert.equal(currentRun, 5)
+//   }, 5)
+// })
 
-retry('test retry async', async function (assert, currentRun) {
-  assert.expect(1)
-  await timeout(100)
-  assert.equal(currentRun, 4)
-}, 4)
+// QUnit.module('test retries, should stop at 3 retries', hooks => {
+//   hooks.after(assert => {
+//     assert.equal(QUnit.config.current.assertions[0].message, '(Retried 3 times)', 'message shows retries')
+//   })
 
-retry('promise reject', async function (assert, currentRun) {
-  if (currentRun === 2) {
-    await Promise.reject(new Error('should be handled'))
-  }
-  assert.equal(currentRun, 5)
-}, 5)
+//   retry('test retry five times', function (assert, currentRun) {
+//     assert.equal(currentRun, 3)
+//   }, 5)
+// })
 
-QUnit.module('hook context', function (hooks) {
-  hooks.beforeEach(function () {
-    this.sharedValue = 'myContext'
-  })
+// retry('test default: retry runs twice - initial attempt plus one retry', function (assert, currentRun) {
+//   assert.expect(1)
+//   assert.equal(currentRun, 2)
+// })
 
-  QUnit.test('qunit test', function (assert) {
-    assert.equal(this.sharedValue, 'myContext')
-  })
+// retry('test retry five times', function (assert, currentRun) {
+//   assert.expect(1)
+//   assert.equal(currentRun, 5)
+// }, 5)
 
-  retry('retry matches qunit test behaviour', function (assert, currentRun) {
-    assert.equal(this.sharedValue, 'myContext')
-    assert.equal(currentRun, 2)
-  })
+// retry('test retry async', async function (assert, currentRun) {
+//   assert.expect(1)
+//   await timeout(100)
+//   assert.equal(currentRun, 4)
+// }, 4)
 
-  retry('environment it reset on each retry', function (assert, currentRun) {
-    assert.equal(this.localValue, undefined)
-    this.localValue = 'local'
-    assert.equal(currentRun, 2)
-  })
-})
+// retry('promise reject', async function (assert, currentRun) {
+//   if (currentRun === 2) {
+//     await Promise.reject(new Error('should be handled'))
+//   }
+//   assert.equal(currentRun, 5)
+// }, 5)
 
-QUnit.module('currentRun count', function () {
-  // tests are order dependent
-  // count retries in retryTest
-  // assert correct count in another test
-  let execCount = 0
+// QUnit.module('hook context', function (hooks) {
+//   hooks.beforeEach(function () {
+//     this.sharedValue = 'myContext'
+//   })
 
-  retry('count retries', function (assert, currentRun) {
-    execCount = execCount + 1
-    assert.equal(currentRun, 5)
-  }, 5)
+//   QUnit.test('qunit test', function (assert) {
+//     assert.equal(this.sharedValue, 'myContext')
+//   })
 
-  QUnit.test('execCount for retryTest', function (assert) {
-    assert.equal(execCount, 5)
-  })
-})
+//   retry('retry matches qunit test behaviour', function (assert, currentRun) {
+//     assert.equal(this.sharedValue, 'myContext')
+//     assert.equal(currentRun, 2)
+//   })
 
-QUnit.module('hooks count', function () {
-  // tests are order dependent
-  // count retries in retryTest
-  // assert correct count in another test
-  let execCount = 0
-  let beforeCount = 0
-  let afterCount = 0
+//   retry('environment it reset on each retry', function (assert, currentRun) {
+//     assert.equal(this.localValue, undefined)
+//     this.localValue = 'local'
+//     assert.equal(currentRun, 2)
+//   })
+// })
 
-  QUnit.module('count hooks async', function (hooks) {
-    hooks.beforeEach(async function () {
-      await timeout(100)
-      beforeCount++
-    })
-    hooks.afterEach(async function () {
-      await timeout(100)
-      afterCount++
-    })
+// QUnit.module('currentRun count', function () {
+//   // tests are order dependent
+//   // count retries in retryTest
+//   // assert correct count in another test
+//   let execCount = 0
 
-    retry('count retries', function (assert, currentRun) {
-      execCount++
-      assert.equal(beforeCount, currentRun, 'beforeCount should match currentRun')
-      assert.equal(afterCount, currentRun - 1, 'afterCount one less than currentRun')
-      assert.equal(currentRun, 5)
-    }, 5)
-  })
+//   retry('count retries', function (assert, currentRun) {
+//     execCount = execCount + 1
+//     assert.equal(currentRun, 5)
+//   }, 5)
 
-  QUnit.test('test hooks count', function (assert) {
-    assert.equal(execCount, 5)
-    assert.equal(beforeCount, 5)
-    assert.equal(afterCount, 5)
-  })
-})
+//   QUnit.test('execCount for retryTest', function (assert) {
+//     assert.equal(execCount, 5)
+//   })
+// })
+
+// QUnit.module('hooks count', function () {
+//   // tests are order dependent
+//   // count retries in retryTest
+//   // assert correct count in another test
+//   let execCount = 0
+//   let beforeCount = 0
+//   let afterCount = 0
+
+//   QUnit.module('count hooks async', function (hooks) {
+//     hooks.beforeEach(async function () {
+//       await timeout(100)
+//       beforeCount++
+//     })
+//     hooks.afterEach(async function () {
+//       await timeout(100)
+//       afterCount++
+//     })
+
+//     retry('count retries', function (assert, currentRun) {
+//       execCount++
+//       assert.equal(beforeCount, currentRun, 'beforeCount should match currentRun')
+//       assert.equal(afterCount, currentRun - 1, 'afterCount one less than currentRun')
+//       assert.equal(currentRun, 5)
+//     }, 5)
+//   })
+
+//   QUnit.test('test hooks count', function (assert) {
+//     assert.equal(execCount, 5)
+//     assert.equal(beforeCount, 5)
+//     assert.equal(afterCount, 5)
+//   })
+// })


### PR DESCRIPTION
This branch demonstrates issues with testem todo reporting.

1. `npm exec qunit`
  a. ❌ Does not run Firefox
  b. ✅ Reports correctly 1 todo and 1 fail
2. `testem ci`
  a. ✅ Reports correctly 1 todo and 1 fail from the Firefox launcher
  b. ❌ Reports incorrectly 2 fails from the `qunit` launcher
3. `testem ci` with `protocol: "process"` in `testem.json`:
  a. ✅ Reports correctly 1 todo and 1 fail from the Firefox launcher
  b. ⚠️ Reports partially correct 1 fail from the `qunit` launcher. Logs are not readable