### PR TITLE
feat: support test.each, test.todo etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ qunit-retry
 Drop in replacement for [QUnit](https://qunitjs.com/) [test](https://api.qunitjs.com/QUnit/test) to `retry` test upon failure.
 
 ```js
+const setup = require('qunit-retry');
+
+const retry = setup(QUnit.test);
+
 // retry this test on failure as third party service occasionally fails
 // we need to test against third party service
 // we can live with occasional third party service failure
@@ -18,6 +22,8 @@ retry("a test relying on 3rd party service that occasionally fails", async funct
   assert.equal(result, 42);
 });
 ```
+
+It provides the same API as `QUnit.test`, including `test.each`, `test.only` etc. The only difference is that the test will be retried upon failure.
 
 Use very sparingly, for a suite of 2024 tests, using this for a single acceptance test.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Blog post about `qunit-retry` available [here](https://blog.mrloop.com/javascrip
 
 ### Set Max Runs
 
-To change the number of retries, set a value in the third parameter (`maxRuns`). The default value for `maxRuns` is `2` (one attempt and one retry):
+The default maximum number of retries is 2 (one attempt and one retry). To change it globally, pass an additional argument to the `setup` function:
+
+```js
+const setup = require('qunit-retry');
+
+const retry = setup(QUnit.test, 3); // sets maxRuns to 3
+```
+
+To change it for a single test, pass the number of retries as the third argument:
 
 ```js
 // retry this test **two times** (in addition to one initial attempt)

--- a/main.js
+++ b/main.js
@@ -4,8 +4,15 @@ export default function setup (testFn) {
   const retry = function (name, callback, maxRuns = 2) {
     return new Retry([name], callback, maxRuns, testFn)
   }
+  retry.todo = function (name, callback, maxRuns) {
+    return new Retry([name], callback, maxRuns, testFn.todo)
+  }
+
   retry.each = function (name, dataset, callback, maxRuns = 2) {
     return new Retry([name, dataset], callback, maxRuns, testFn.each)
+  }
+  retry.todo.each = function (name, dataset, callback, maxRuns) {
+    return new Retry([name, dataset], callback, maxRuns, testFn.todo.each)
   }
   return retry
 }

--- a/main.js
+++ b/main.js
@@ -13,6 +13,9 @@ export default function setup (testFn) {
   retry.if = function (name, condition, callback, maxRuns = 2) {
     return new Retry([name, condition], callback, maxRuns, testFn.if)
   }
+  retry.only = function (name, callback, maxRuns) {
+    return new Retry([name], callback, maxRuns, testFn.only)
+  }
 
   retry.each = function (name, dataset, callback, maxRuns = 2) {
     return new Retry([name, dataset], callback, maxRuns, testFn.each)
@@ -25,6 +28,9 @@ export default function setup (testFn) {
   }
   retry.if.each = function (name, condition, dataset, callback, maxRuns = 2) {
     return new Retry([name, condition, dataset], callback, maxRuns, testFn.if.each)
+  }
+  retry.only.each = function (name, dataset, callback, maxRuns) {
+    return new Retry([name, dataset], callback, maxRuns, testFn.only.each)
   }
   return retry
 }

--- a/main.js
+++ b/main.js
@@ -1,7 +1,11 @@
 import Retry from './src/retry.js'
 
 export default function setup (testFn) {
-  return function retry (name, callback, maxRuns = 2) {
-    return new Retry(name, callback, maxRuns, testFn)
+  const retry = function (name, callback, maxRuns = 2) {
+    return new Retry([name], callback, maxRuns, testFn)
   }
+  retry.each = function (name, dataset, callback, maxRuns = 2) {
+    return new Retry([name, dataset], callback, maxRuns, testFn.each)
+  }
+  return retry
 }

--- a/main.js
+++ b/main.js
@@ -1,35 +1,35 @@
 import Retry from './src/retry.js'
 
-export default function setup (testFn) {
-  const retry = function (name, callback, maxRuns = 2) {
+export default function setup (testFn, defaultMaxRuns = 2) {
+  const retry = function (name, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name], callback, maxRuns, testFn)
   }
-  retry.todo = function (name, callback, maxRuns) {
+  retry.todo = function (name, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name], callback, maxRuns, testFn.todo)
   }
-  retry.skip = function (name, callback, maxRuns) {
+  retry.skip = function (name, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name], callback, maxRuns, testFn.skip)
   }
-  retry.if = function (name, condition, callback, maxRuns = 2) {
+  retry.if = function (name, condition, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, condition], callback, maxRuns, testFn.if)
   }
-  retry.only = function (name, callback, maxRuns) {
+  retry.only = function (name, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name], callback, maxRuns, testFn.only)
   }
 
-  retry.each = function (name, dataset, callback, maxRuns = 2) {
+  retry.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.each)
   }
-  retry.todo.each = function (name, dataset, callback, maxRuns) {
+  retry.todo.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.todo.each)
   }
-  retry.skip.each = function (name, dataset, callback, maxRuns) {
+  retry.skip.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.skip.each)
   }
-  retry.if.each = function (name, condition, dataset, callback, maxRuns = 2) {
+  retry.if.each = function (name, condition, dataset, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, condition, dataset], callback, maxRuns, testFn.if.each)
   }
-  retry.only.each = function (name, dataset, callback, maxRuns) {
+  retry.only.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.only.each)
   }
   return retry

--- a/main.js
+++ b/main.js
@@ -7,12 +7,18 @@ export default function setup (testFn) {
   retry.todo = function (name, callback, maxRuns) {
     return new Retry([name], callback, maxRuns, testFn.todo)
   }
+  retry.skip = function (name, callback, maxRuns) {
+    return new Retry([name], callback, maxRuns, testFn.skip)
+  }
 
   retry.each = function (name, dataset, callback, maxRuns = 2) {
     return new Retry([name, dataset], callback, maxRuns, testFn.each)
   }
   retry.todo.each = function (name, dataset, callback, maxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.todo.each)
+  }
+  retry.skip.each = function (name, dataset, callback, maxRuns) {
+    return new Retry([name, dataset], callback, maxRuns, testFn.skip.each)
   }
   return retry
 }

--- a/main.js
+++ b/main.js
@@ -10,6 +10,9 @@ export default function setup (testFn) {
   retry.skip = function (name, callback, maxRuns) {
     return new Retry([name], callback, maxRuns, testFn.skip)
   }
+  retry.if = function (name, condition, callback, maxRuns = 2) {
+    return new Retry([name, condition], callback, maxRuns, testFn.if)
+  }
 
   retry.each = function (name, dataset, callback, maxRuns = 2) {
     return new Retry([name, dataset], callback, maxRuns, testFn.each)
@@ -19,6 +22,9 @@ export default function setup (testFn) {
   }
   retry.skip.each = function (name, dataset, callback, maxRuns) {
     return new Retry([name, dataset], callback, maxRuns, testFn.skip.each)
+  }
+  retry.if.each = function (name, condition, dataset, callback, maxRuns = 2) {
+    return new Retry([name, condition, dataset], callback, maxRuns, testFn.if.each)
   }
   return retry
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "pnpm test:smoke lint && pnpm test:js && pnpm test:smoke",
     "test:smoke": "testem ci",
-    "test:js": "qunit",
+    "test:js": "qunit test/retry.js && qunit test/retry-only.js",
     "dev": "qunit --watch",
     "lint": "eslint index.js"
   },

--- a/test/retry-only.js
+++ b/test/retry-only.js
@@ -1,0 +1,44 @@
+const setup = require('../index.js')
+const QUnit = require('qunit')
+
+const retry = setup(QUnit.test)
+
+QUnit.module('retry.only', function () {
+  const calls = []
+
+  retry.only('count only retries', function (assert, currentRun) {
+    calls.push(['only', currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  retry('count non-only retries', function (assert, currentRun) {
+    calls.push(['non-only', currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['only', 1], ['only', 2]])
+  })
+})
+
+QUnit.module('retry.only.each', function () {
+  const calls = []
+
+  retry.only.each('count only retries', ['A', 'B'], function (assert, data, currentRun) {
+    calls.push(['only', data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  retry.each('count non-only retries', ['A', 'B'], function (assert, data, currentRun) {
+    calls.push(['non-only', data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['only', 'A', 1], ['only', 'A', 2], ['only', 'B', 1], ['only', 'B', 2]])
+  })
+})

--- a/test/retry.js
+++ b/test/retry.js
@@ -119,6 +119,21 @@ QUnit.module('hooks count', function () {
   })
 })
 
+QUnit.module('default max runs', function () {
+  const calls = []
+  const retryThrice = setup(QUnit.test, 3)
+
+  retryThrice('count retries', function (assert, currentRun) {
+    calls.push(currentRun)
+
+    assert.equal(currentRun, 3)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [1, 2, 3])
+  })
+})
+
 QUnit.module('retry.todo', function () {
   const calls = []
 

--- a/test/retry.js
+++ b/test/retry.js
@@ -118,3 +118,17 @@ QUnit.module('hooks count', function () {
     assert.equal(afterCount, 5)
   })
 })
+
+QUnit.module('retry.each', function () {
+  const calls = []
+
+  retry.each('count retries', ['A', 'B', 'C'], function (assert, data, currentRun) {
+    calls.push([data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['A', 1], ['A', 2], ['B', 1], ['B', 2], ['C', 1], ['C', 2]])
+  })
+})

--- a/test/retry.js
+++ b/test/retry.js
@@ -147,6 +147,26 @@ QUnit.module('retry.skip', function () {
   })
 })
 
+QUnit.module('retry.if', function () {
+  const calls = []
+
+  retry.if('count true retries', true, function (assert, currentRun) {
+    calls.push([true, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  retry.if('count false retries', false, function (assert, currentRun) {
+    calls.push([false, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [[true, 1], [true, 2]])
+  })
+})
+
 QUnit.module('retry.each', function () {
   const calls = []
 
@@ -186,5 +206,25 @@ QUnit.module('retry.skip.each', function () {
 
   QUnit.test('verify calls', function (assert) {
     assert.deepEqual(calls, [])
+  })
+})
+
+QUnit.module('retry.if.each', function () {
+  const calls = []
+
+  retry.if.each('count true retries', true, ['A', 'B'], function (assert, data, currentRun) {
+    calls.push([true, data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  retry.if.each('count false retries', false, ['A', 'B'], function (assert, data, currentRun) {
+    calls.push([false, data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [[true, 'A', 1], [true, 'A', 2], [true, 'B', 1], [true, 'B', 2]])
   })
 })

--- a/test/retry.js
+++ b/test/retry.js
@@ -119,6 +119,20 @@ QUnit.module('hooks count', function () {
   })
 })
 
+QUnit.module('retry.todo', function () {
+  const calls = []
+
+  retry.todo('count retries', function (assert, currentRun) {
+    calls.push(currentRun)
+
+    assert.ok(false)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [1, 2])
+  })
+})
+
 QUnit.module('retry.each', function () {
   const calls = []
 
@@ -126,6 +140,20 @@ QUnit.module('retry.each', function () {
     calls.push([data, currentRun])
 
     assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['A', 1], ['A', 2], ['B', 1], ['B', 2], ['C', 1], ['C', 2]])
+  })
+})
+
+QUnit.module('retry.todo.each', function () {
+  const calls = []
+
+  retry.todo.each('count retries', ['A', 'B', 'C'], function (assert, data, currentRun) {
+    calls.push([data, currentRun])
+
+    assert.ok(false)
   })
 
   QUnit.test('verify calls', function (assert) {

--- a/test/retry.js
+++ b/test/retry.js
@@ -133,6 +133,20 @@ QUnit.module('retry.todo', function () {
   })
 })
 
+QUnit.module('retry.skip', function () {
+  const calls = []
+
+  retry.skip('count retries', function (assert, currentRun) {
+    calls.push(currentRun)
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [])
+  })
+})
+
 QUnit.module('retry.each', function () {
   const calls = []
 
@@ -158,5 +172,19 @@ QUnit.module('retry.todo.each', function () {
 
   QUnit.test('verify calls', function (assert) {
     assert.deepEqual(calls, [['A', 1], ['A', 2], ['B', 1], ['B', 2], ['C', 1], ['C', 2]])
+  })
+})
+
+QUnit.module('retry.skip.each', function () {
+  const calls = []
+
+  retry.skip.each('count retries', ['A', 'B', 'C'], function (assert, data, currentRun) {
+    calls.push([data, currentRun])
+
+    assert.equal(currentRun, 2)
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [])
   })
 })


### PR DESCRIPTION
This MR adds support for [all the test methods provided by QUnit](https://qunitjs.com/api/QUnit/test.each/):

- `test.if`
- `test.only`
- `test.skip`
- `test.todo`
- `test.each`
- `test.if.each`
- `test.only.each`
- `test.skip.each`
- `test.todo.each`

To allow setting `maxRuns` only once globally, a new argument was added to `setup`:

```javascript
// sets maxRuns to 3 for all methods
const retry = setup(QUnit.test, 3)
```
