### PR TITLE
fix: avoid false positives when the failed assertion is not the last one

### DIFF
--- a/src/assert-result-handler.js
+++ b/src/assert-result-handler.js
@@ -1,6 +1,7 @@
 export default class AssertResultHandler {
   constructor (retryObj) {
     this.retry = retryObj
+    this.isSuccess = true
   }
 
   get (target, prop, receiver) {
@@ -15,13 +16,9 @@ export default class AssertResultHandler {
     return `${message}(Retried ${retryNum} times)`
   }
 
-  get isSuccess () {
-    return this.lastResult && this.lastResult.result
-  }
-
   pushResultFn (target) {
     return (result) => {
-      this.lastResult = result
+      this.isSuccess = this.isSuccess && result.result
       if (!this.retry.shouldRetry) {
         result.message = this.retryMessage(result.message, this.retry.currentRun)
         target.pushResult(result)

--- a/src/assert-result-handler.js
+++ b/src/assert-result-handler.js
@@ -1,7 +1,6 @@
 export default class AssertResultHandler {
   constructor (retryObj) {
     this.retry = retryObj
-    this.isSuccess = true
   }
 
   get (target, prop, receiver) {
@@ -18,7 +17,7 @@ export default class AssertResultHandler {
 
   pushResultFn (target) {
     return (result) => {
-      this.isSuccess = this.isSuccess && result.result
+      this.retry.isSuccess = this.retry.isSuccess && result.result
       if (!this.retry.shouldRetry) {
         result.message = this.retryMessage(result.message, this.retry.currentRun)
         target.pushResult(result)

--- a/src/retry.js
+++ b/src/retry.js
@@ -59,6 +59,7 @@ export default class Retry {
 
   async runTest () {
     if (this.notFirstRun) {
+      this.assertResultHandler.isSuccess = true
       this.test.testEnvironment = extend({}, this.test.module.testEnvironment, false, true)
       await this.runHooks(this.beforeEachHooks)
     }
@@ -73,9 +74,10 @@ export default class Retry {
     try {
       await this.callback.call(this.testEnvironment, this.assertProxy, ...this.callbackArgs, this.currentRun)
     } catch (err) {
-      if (!this.shouldRetry) {
-        throw err
-      }
+      this.assertProxy.pushResult({
+        result: false,
+        message: err.message
+      })
     }
   }
 

--- a/src/retry.js
+++ b/src/retry.js
@@ -6,6 +6,7 @@ export default class Retry {
     this.callback = callback
     this.maxRuns = maxRuns
     this.assertResultHandler = new AssertResultHandler(this)
+    this.isSuccess = true
 
     testFn(...args, async (assert, ...callbackArgs) => {
       this.assertProxy = new Proxy(assert, this.assertResultHandler)
@@ -16,7 +17,7 @@ export default class Retry {
   }
 
   get shouldRetry () {
-    return this.currentRun < this.maxRuns && !this.assertResultHandler.isSuccess
+    return this.currentRun < this.maxRuns && !this.isSuccess
   }
 
   get test () {
@@ -59,7 +60,7 @@ export default class Retry {
 
   async runTest () {
     if (this.notFirstRun) {
-      this.assertResultHandler.isSuccess = true
+      this.isSuccess = true
       this.test.testEnvironment = extend({}, this.test.module.testEnvironment, false, true)
       await this.runHooks(this.beforeEachHooks)
     }

--- a/test/retry.js
+++ b/test/retry.js
@@ -42,12 +42,45 @@ retry('test retry async', async function (assert, currentRun) {
   assert.equal(currentRun, 4)
 }, 4)
 
-retry('promise reject', async function (assert, currentRun) {
-  if (currentRun === 2) {
-    await Promise.reject(new Error('should be handled'))
-  }
-  assert.equal(currentRun, 5)
-}, 5)
+QUnit.module('error handling', function () {
+  retry('rejected promise is handled', async function (assert, currentRun) {
+    if (currentRun === 2) {
+      await Promise.reject(new Error('should be handled'))
+    }
+    assert.equal(currentRun, 5)
+  }, 5)
+
+  retry.todo('rejected promise on the last try is is not handled', async function (assert, currentRun) {
+    if (currentRun === 5) {
+      await Promise.reject(new Error('should not be handled'))
+    }
+    assert.equal(currentRun, 5)
+  }, 5)
+
+  retry('error is handled', async function (assert, currentRun) {
+    if (currentRun === 2) {
+      throw new Error('should be handled')
+    }
+    assert.equal(currentRun, 5)
+  }, 5)
+
+  retry.todo('error on the last try is not handled', async function (assert, currentRun) {
+    if (currentRun === 5) {
+      throw new Error('should not be handled')
+    }
+    assert.equal(currentRun, 5)
+  }, 5)
+
+  retry('failed assertion is handled', async function (assert, currentRun) {
+    assert.equal(currentRun, 5)
+    assert.ok(true)
+  }, 5)
+
+  retry.todo('failed assertion on the last try is not handled', async function (assert, currentRun) {
+    assert.ok(false)
+    assert.ok(true)
+  }, 5)
+})
 
 QUnit.module('hook context', function (hooks) {
   hooks.beforeEach(function () {


### PR DESCRIPTION
This MR fixes false positives error that occurs when one of several sync assertions fails:

```js
retry('failed assertion on the last try is not handled', async function (assert, currentRun) {
  assert.ok(false)
  assert.ok(true)
}, 5)
```

This test should fail, but it passes. It's caused by leveraging last result to determine if the test is successful or not - last result might not be the failed one.

To fix the issue, I propose an alternative approach where `isSuccess` is updated on each push. That way we make sure it cannot go from `false` to `true` on the same run:

```diff
- this.lastResult = result
+ this.isSuccess = this.isSuccess && result.result
```

This approach didn't play well with error rethrowing - these errors didn't trigger `pushResult` so they didn't update `isSuccess` correctly. I use `pushResult` instead.

```diff
try {
  await this.callback.call(this.testEnvironment, this.assertProxy, ...this.callbackArgs, this.currentRun)
} catch (err) {
-  if (!this.shouldRetry) {
-    throw err
-  }
+  this.assertProxy.pushResult({
+    result: false,
+    message: err.message
+  })
}
```

I tried to cover all scenarios to make sure no failed tests are missed. To test a failing test I use `retry.todo` which is successful when the test fails.