### PR TITLE
feat: support assert.expect with reruns

### DIFF
--- a/src/assert-result-handler.js
+++ b/src/assert-result-handler.js
@@ -4,8 +4,11 @@ export default class AssertResultHandler {
   }
 
   get (target, prop, receiver) {
-    if (prop === 'pushResult') {
-      return this.pushResultFn(target)
+    switch (prop) {
+      case 'pushResult':
+        return this.pushResultFn(target)
+      case 'expect':
+        return this.expectFn(target)
     }
     return Reflect.get(target, prop, receiver)
   }
@@ -22,6 +25,12 @@ export default class AssertResultHandler {
         result.message = this.retryMessage(result.message, this.retry.currentRun)
         target.pushResult(result)
       }
+    }
+  }
+
+  expectFn (target) {
+    return count => {
+      target.expect(count + target.test.assertions.length)
     }
   }
 }

--- a/test/retry.js
+++ b/test/retry.js
@@ -167,6 +167,41 @@ QUnit.module('default max runs', function () {
   })
 })
 
+QUnit.module('assert.expect', function () {
+  const calls = []
+
+  retry('should pass with retries', function (assert, currentRun) {
+    calls.push(['with', currentRun])
+
+    assert.expect(3)
+    assert.ok(true)
+    if (currentRun === 1) { throw new Error('fail') }
+    assert.ok(true)
+    if (currentRun === 2) { throw new Error('fail') }
+    assert.ok(true)
+  }, 3)
+
+  retry('should pass without retries', function (assert, currentRun) {
+    calls.push(['without', currentRun])
+
+    assert.expect(2)
+    assert.ok(true)
+    assert.ok(true)
+  })
+
+  retry.todo('should fail with incorrect count', function (assert, currentRun) {
+    calls.push(['incorrect', currentRun])
+
+    assert.expect(2)
+    assert.ok(true)
+    if (currentRun === 1) { throw new Error('fail') }
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['with', 1], ['with', 2], ['with', 3], ['without', 1], ['incorrect', 1], ['incorrect', 2]])
+  })
+})
+
 QUnit.module('retry.todo', function () {
   const calls = []
 


### PR DESCRIPTION
This MR adds support for `assert.expect`.

Currently `assert.expect` counts all assertions including these performed in previous tries:

```js
  retry('should pass with retries', function (assert, currentRun) {
    assert.expect(2)
    assert.ok(true) // run twice
    if (currentRun === 1) { throw new Error('fail') }
    assert.ok(true) // run once
  })
```

In this example the total number of assertions is 3: 1 for the first run + 2 for the second one. The test fails even though the second attempt should be considered successful.

To mitigate this issue, I proxy the `expect` method and add the number of the assertions already performed in the previous runs:

```js
  expectFn (target) {
    return count => {
      target.expect(count + target.test.assertions.length)
    }
  }
```