### PR TITLE
fix: make sure assert.throws uses our assert proxy

### DIFF
--- a/src/retry.js
+++ b/src/retry.js
@@ -11,6 +11,7 @@ export default class Retry {
     testFn(...args, async (assert, ...callbackArgs) => {
       this.assertProxy = new Proxy(assert, this.assertResultHandler)
       this.callbackArgs = callbackArgs
+      assert.test.assert = this.assertProxy
       this.currentRun = 1
       await this.retry(this.currentRun)
     })

--- a/test/retry.js
+++ b/test/retry.js
@@ -202,6 +202,22 @@ QUnit.module('assert.expect', function () {
   })
 })
 
+QUnit.module('assert.throws', function () {
+  const calls = []
+
+  retry('count retries', function (assert, currentRun) {
+    calls.push(currentRun)
+
+    assert.throws(() => {
+      if (currentRun === 2) throw new Error('fail')
+    })
+  })
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [1, 2])
+  })
+})
+
 QUnit.module('retry.todo', function () {
   const calls = []
 


### PR DESCRIPTION
This MR adds missing `assert.throws` compatibility.

In the contrast to other assert methods, `assert.throws` doesn't use our `assert` proxy. [It reaches for `currentTest.assert`](https://github.com/qunitjs/qunit/blob/d37b877686f8ac36c4abbd39fc223f500df4cdb5/src/core/assert.js#L278), which is the original `assert` object.

The issue can be fixed by overriding the `test.assert` property with our proxy.