### PR TITLE
feat: accept beforeRetry hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ retry("a test relying on 3rd party service that occasionally fails", async funct
 
 **Note:** It is generally advised to use the retry sparingly and this advice extends to setting a large number of retries.
 
+### Resetting environment between retries
+
+If you need to reset the environment between retries, you can pass a `beforeRetry` function to the `setup` function:
+
+```js
+const setup = require('qunit-retry');
+
+const retry = setup(QUnit.test, { beforeRetry: () => resetEnvironment() });
+```
+
 Install
 ------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Blog post about `qunit-retry` available [here](https://blog.mrloop.com/javascrip
 
 ### Set Max Runs
 
-The default maximum number of retries is 2 (one attempt and one retry). To change it globally, pass an additional argument to the `setup` function:
+The default maximum number of retries is 2 (one attempt and one retry). To change it globally, pass the `maxRuns` option to the `setup` function:
 
 ```js
 const setup = require('qunit-retry');
 
-const retry = setup(QUnit.test, 3); // sets maxRuns to 3
+const retry = setup(QUnit.test, { maxRuns: 3 });
 ```
 
 To change it for a single test, pass the number of retries as the third argument:

--- a/main.js
+++ b/main.js
@@ -1,36 +1,36 @@
 import Retry from './src/retry.js'
 
-export default function setup (testFn, { maxRuns: defaultMaxRuns = 2 } = {}) {
+export default function setup (testFn, { maxRuns: defaultMaxRuns = 2, beforeRetry } = {}) {
   const retry = function (name, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name], callback, maxRuns, testFn)
+    return new Retry([name], callback, maxRuns, testFn, beforeRetry)
   }
   retry.todo = function (name, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name], callback, maxRuns, testFn.todo)
+    return new Retry([name], callback, maxRuns, testFn.todo, beforeRetry)
   }
   retry.skip = function (name, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name], callback, maxRuns, testFn.skip)
+    return new Retry([name], callback, maxRuns, testFn.skip, beforeRetry)
   }
   retry.if = function (name, condition, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, condition], callback, maxRuns, testFn.if)
+    return new Retry([name, condition], callback, maxRuns, testFn.if, beforeRetry)
   }
   retry.only = function (name, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name], callback, maxRuns, testFn.only)
+    return new Retry([name], callback, maxRuns, testFn.only, beforeRetry)
   }
 
   retry.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, dataset], callback, maxRuns, testFn.each)
+    return new Retry([name, dataset], callback, maxRuns, testFn.each, beforeRetry)
   }
   retry.todo.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, dataset], callback, maxRuns, testFn.todo.each)
+    return new Retry([name, dataset], callback, maxRuns, testFn.todo.each, beforeRetry)
   }
   retry.skip.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, dataset], callback, maxRuns, testFn.skip.each)
+    return new Retry([name, dataset], callback, maxRuns, testFn.skip.each, beforeRetry)
   }
   retry.if.each = function (name, condition, dataset, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, condition, dataset], callback, maxRuns, testFn.if.each)
+    return new Retry([name, condition, dataset], callback, maxRuns, testFn.if.each, beforeRetry)
   }
   retry.only.each = function (name, dataset, callback, maxRuns = defaultMaxRuns) {
-    return new Retry([name, dataset], callback, maxRuns, testFn.only.each)
+    return new Retry([name, dataset], callback, maxRuns, testFn.only.each, beforeRetry)
   }
   return retry
 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import Retry from './src/retry.js'
 
-export default function setup (testFn, defaultMaxRuns = 2) {
+export default function setup (testFn, { maxRuns: defaultMaxRuns = 2 } = {}) {
   const retry = function (name, callback, maxRuns = defaultMaxRuns) {
     return new Retry([name], callback, maxRuns, testFn)
   }

--- a/src/retry.js
+++ b/src/retry.js
@@ -2,9 +2,10 @@ import AssertResultHandler from './assert-result-handler.js'
 import extend from './extend.js'
 
 export default class Retry {
-  constructor (args, callback, maxRuns = 2, testFn) {
+  constructor (args, callback, maxRuns = 2, testFn, beforeRetry) {
     this.callback = callback
     this.maxRuns = maxRuns
+    this.beforeRetry = beforeRetry
     this.assertResultHandler = new AssertResultHandler(this)
     this.isSuccess = true
 
@@ -60,6 +61,9 @@ export default class Retry {
 
   async runTest () {
     if (this.notFirstRun) {
+      if (this.beforeRetry) {
+        await this.beforeRetry.call(this.testEnvironment, this.assertProxy, this.currentRun)
+      }
       this.isSuccess = true
       this.test.testEnvironment = extend({}, this.test.module.testEnvironment, false, true)
       await this.runHooks(this.beforeEachHooks)

--- a/test/retry.js
+++ b/test/retry.js
@@ -167,6 +167,25 @@ QUnit.module('default max runs', function () {
   })
 })
 
+QUnit.module('beforeRetry hook', function () {
+  const calls = []
+  const retryWithHook = setup(QUnit.test, {
+    beforeRetry: function (assert, currentRun) {
+      calls.push(['hook', currentRun])
+    }
+  })
+
+  retryWithHook('count retries', function (assert, currentRun) {
+    calls.push(['test', currentRun])
+
+    assert.equal(currentRun, 2)
+  }, 2)
+
+  QUnit.test('verify calls', function (assert) {
+    assert.deepEqual(calls, [['test', 1], ['hook', 2], ['test', 2]])
+  })
+})
+
 QUnit.module('assert.expect', function () {
   const calls = []
 

--- a/test/retry.js
+++ b/test/retry.js
@@ -154,7 +154,7 @@ QUnit.module('hooks count', function () {
 
 QUnit.module('default max runs', function () {
   const calls = []
-  const retryThrice = setup(QUnit.test, 3)
+  const retryThrice = setup(QUnit.test, { maxRuns: 3 })
 
   retryThrice('count retries', function (assert, currentRun) {
     calls.push(currentRun)


### PR DESCRIPTION
This MR introduces `beforeRetry` hook in the `setup` function:

```js
const setup = require('qunit-retry');

const retry = setup(QUnit.test, { beforeRetry: () => resetEnvironment() });
```

It allows performing custom reset logic (e.g. recreating Sinon sanbox) between retries.

⚠️ This MR changes the `setup` function signature which currently expects `maxRuns` as a second argument. This MR uses an options object instead. This change was not published on NPM yet, so I think there is no risk in introducing this breaking change.